### PR TITLE
10月末パッチでのUI崩れ

### DIFF
--- a/chatbtn/src/addon_d/chatbtn/chatbtn.lua
+++ b/chatbtn/src/addon_d/chatbtn/chatbtn.lua
@@ -73,7 +73,7 @@ function CHATBTN_CREATE_BUTTONS()
         if g["settings"]["button"..i] == nil then
             g["settings"]["button"..i] = { title = " ", msg = " " };
         end
-        chatbutton[i] = frame:CreateOrGetControl('button', "chatbutton["..i.."]", (g.settings.size - 3) * (i - 1) + 235, 6, g.settings.size, 25);
+        chatbutton[i] = frame:CreateOrGetControl('button', "chatbutton["..i.."]", (g.settings.size - 3) * (i - 1) + 300, 6, g.settings.size, 25);
         chatbutton[i] = tolua.cast(chatbutton[i], "ui::CButton");
         chatbutton[i]:SetText("{s14}"..g["settings"]["button"..i]["title"]);
         chatbutton[i]:SetEventScript(ui.LBUTTONUP, "CHATBTN_ON_CLICK");


### PR DESCRIPTION
はじめまして。アドオン便利に使わせていただいています。
公開ありがとうございます。

10月末のパッチでチャットウィンドウに追加されたボタンの表示領域と、
ChatbtnのUI表示領域が重なってしまっているようです。

UIの座標修正のみで回避できるかと思いますので、
お手数ですが修正の取り込みを検討願えませんでしょうか。
